### PR TITLE
ユーザー一覧に退会済み検索機能を追加

### DIFF
--- a/app/Domain/Repositories/User/UserRepository.php
+++ b/app/Domain/Repositories/User/UserRepository.php
@@ -5,6 +5,7 @@ namespace App\Domain\Repositories\User;
 use App\Domain\Entities\User;
 use App\Domain\Repositories\BaseRepository;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
@@ -20,7 +21,12 @@ class UserRepository extends BaseRepository implements UserRepositoryInterface
      */
     public function getByConditions(array $conditions): Collection|LengthAwarePaginator
     {
-        $query = $this->model->with('avatarImage')->select();
+        /** @var Builder|User $query */
+        $query = $this->model->with('avatarImage');
+
+        if ($conditions['with_trashed']) {
+            $query = $query->withTrashed();
+        }
 
         if (!is_null($conditions['keyword'] ?? null)) {
             $keyword = $conditions['keyword'];

--- a/app/Domain/Repositories/User/UserRepositoryInterface.php
+++ b/app/Domain/Repositories/User/UserRepositoryInterface.php
@@ -17,6 +17,7 @@ interface UserRepositoryInterface extends BaseRepositoryInterface
      *   keyword : ?string,
      *   status : ?UserStatus,
      *   has_google : ?bool,
+     *   with_trashed : bool,
      *   sort_name : ?string,
      *   sort_direction : 'asc' | 'desc' | null,
      *   limit : ?int,

--- a/app/Dto/Request/Admin/User/SearchConditionDto.php
+++ b/app/Dto/Request/Admin/User/SearchConditionDto.php
@@ -16,6 +16,9 @@ class SearchConditionDto
     // Google連携あり
     public ?bool $hasGoogle;
 
+    // 退会済みを含む
+    public bool $withTrashed;
+
     // ソートのカラム名
     public string $sortName;
 
@@ -42,6 +45,7 @@ class SearchConditionDto
         } else {
             $this->hasGoogle = null;
         }
+        $this->withTrashed   = $request->boolean('with_trashed', false);
         $this->sortName      = $request->input('sort_name', 'id'); // デフォルト: id
         $this->sortDirection = in_array($request->input('sort_direction'), ['asc', 'desc']) ? $request->input('sort_direction') : 'desc';
         $this->page          = (int) $request->input('page', 1); // デフォルト: 1

--- a/app/Services/Admin/User/IndexService.php
+++ b/app/Services/Admin/User/IndexService.php
@@ -23,6 +23,7 @@ class IndexService extends BaseService
             'keyword'        => $searchConditionDto->keyword,
             'status'         => $searchConditionDto->status,
             'has_google'     => $searchConditionDto->hasGoogle,
+            'with_trashed'   => $searchConditionDto->withTrashed,
             'sort_name'      => $searchConditionDto->sortName,
             'sort_direction' => $searchConditionDto->sortDirection,
             'limit'          => $searchConditionDto->limit,

--- a/resources/views/admin/user/index.blade.php
+++ b/resources/views/admin/user/index.blade.php
@@ -67,6 +67,22 @@
                         </select>
                     </div>
                 </div>
+
+                <div class="mb-3 row">
+                    <div class="col-sm-2"></div>
+                    <div class="col-sm-4">
+                        <div class="form-check">
+                            <input type="checkbox"
+                                   name="with_trashed"
+                                   id="with_trashed"
+                                   value="1"
+                                   class="form-check-input"
+                                   {{ request()->boolean('with_trashed') ? 'checked' : '' }} />
+                            <label for="with_trashed"
+                                   class="form-check-label fw-bold">退会済みを含む</label>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="card-footer text-center">
                 <button type="submit"
@@ -86,6 +102,11 @@
         <input type="hidden"
                name="has_google"
                value="{{ request()->input('has_google') }}" />
+        @if (request()->boolean('with_trashed'))
+            <input type="hidden"
+                   name="with_trashed"
+                   value="1" />
+        @endif
     </form>
     <div class="row">
         <div class="col-12">
@@ -111,6 +132,7 @@
                                 ])
                                 <th>ステータス</th>
                                 <th>Google</th>
+                                <th>退会</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -135,7 +157,12 @@
                                         @endif
                                     </td>
                                     <td>
-                                        <a class="btn btn-primary btn-sm"
+                                        @if ($user->trashed())
+                                            <span class="badge bg-danger">退会済</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <a class="btn btn-primary btn-sm {{ $user->trashed() ? 'disabled' : '' }}"
                                            href="{{ route('admin.user.show', ['user' => $user]) }}">詳細</a>
                                     </td>
                                 </tr>

--- a/tests/Unit/Domain/Repositories/User/UserRepositoryTest.php
+++ b/tests/Unit/Domain/Repositories/User/UserRepositoryTest.php
@@ -28,6 +28,7 @@ class UserRepositoryTest extends BaseTest
             'keyword'        => null,
             'status'         => null,
             'has_google'     => null,
+            'with_trashed'   => false,
             'sort_name'      => null,
             'sort_direction' => null,
             'limit'          => null,
@@ -67,12 +68,39 @@ class UserRepositoryTest extends BaseTest
         $this->assertSame(1, $users->count(), 'limitで取得件数が指定出来ることをテスト');
     }
 
+    public function test_getByConditions_with_trashedで退会済みユーザーを含めて取得できること(): void
+    {
+        $defaultConditions = [
+            'keyword'        => null,
+            'status'         => null,
+            'has_google'     => null,
+            'with_trashed'   => false,
+            'sort_name'      => 'id',
+            'sort_direction' => 'asc',
+            'limit'          => null,
+        ];
+
+        $activeUser  = $this->createDefaultUser();
+        $deletedUser = $this->createDefaultUser();
+        $deletedUser->delete();
+
+        $users = $this->repository->getByConditions($defaultConditions);
+        $this->assertSame([$activeUser->id], $users->pluck('id')->all(), 'デフォルトでは退会済みユーザーが含まれないことをテスト');
+
+        $users = $this->repository->getByConditions([
+            ...$defaultConditions,
+            'with_trashed' => true,
+        ]);
+        $this->assertSame([$activeUser->id, $deletedUser->id], $users->pluck('id')->all(), 'with_trashedがtrueの場合は退会済みユーザーが含まれることをテスト');
+    }
+
     public function test_getByConditions_statusで絞り込めること(): void
     {
         $defaultConditions = [
             'keyword'        => null,
             'status'         => null,
             'has_google'     => null,
+            'with_trashed'   => false,
             'sort_name'      => null,
             'sort_direction' => null,
             'limit'          => null,
@@ -102,6 +130,7 @@ class UserRepositoryTest extends BaseTest
             'keyword'        => null,
             'status'         => null,
             'has_google'     => null,
+            'with_trashed'   => false,
             'sort_name'      => null,
             'sort_direction' => null,
             'limit'          => null,

--- a/tests/Unit/Dto/Request/Admin/User/SearchConditionDtoTest.php
+++ b/tests/Unit/Dto/Request/Admin/User/SearchConditionDtoTest.php
@@ -15,6 +15,7 @@ class SearchConditionDtoTest extends BaseTest
             'keyword'        => 'テストユーザー',
             'status'         => '0',
             'has_google'     => '1',
+            'with_trashed'   => '1',
             'sort_name'      => 'email',
             'sort_direction' => 'asc',
             'page'           => '2',
@@ -26,6 +27,7 @@ class SearchConditionDtoTest extends BaseTest
         $this->assertSame('テストユーザー', $dto->keyword);
         $this->assertSame(UserStatus::Active, $dto->status);
         $this->assertTrue($dto->hasGoogle);
+        $this->assertTrue($dto->withTrashed);
         $this->assertSame('email', $dto->sortName);
         $this->assertSame('asc', $dto->sortDirection);
         $this->assertSame(2, $dto->page);
@@ -49,10 +51,29 @@ class SearchConditionDtoTest extends BaseTest
 
         $dto = new SearchConditionDto($request);
 
+        $this->assertFalse($dto->withTrashed);
         $this->assertSame('id', $dto->sortName);
         $this->assertSame('desc', $dto->sortDirection);
         $this->assertSame(1, $dto->page);
         $this->assertSame(20, $dto->limit);
+    }
+
+    public function test_construct_with_trashedが1の場合trueになること(): void
+    {
+        $request = Request::create('/', 'GET', ['with_trashed' => '1']);
+
+        $dto = new SearchConditionDto($request);
+
+        $this->assertTrue($dto->withTrashed);
+    }
+
+    public function test_construct_with_trashedが未指定の場合falseになること(): void
+    {
+        $request = Request::create('/', 'GET');
+
+        $dto = new SearchConditionDto($request);
+
+        $this->assertFalse($dto->withTrashed);
     }
 
     public function test_construct_keywordが空文字の場合nullになること(): void


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->

* 管理画面のユーザー一覧において、退会済み（論理削除済み）のユーザーを検索・確認できるようにするため、検索条件に「退会済みを含む」オプションを追加しました。


## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->

* https://xxxxxxxxxxxxxxxx

## やったこと
<!-- このPRで何をしたのか？ -->

- [X] `UserRepository` の検索処理に `withTrashed()` を適用するロジックを追加しました。
- [X] `SearchConditionDto` を拡張し、リクエストから `with_trashed` フラグを受け取れるようにしました。
- [X] ユーザー一覧画面の検索フォームに「退会済みを含む」チェックボックスを追加しました。
- [X] 検索結果一覧に「退会」列を追加し、退会済みユーザーにはバッジを表示するようにしました。
- [X] 退会済みユーザーの詳細画面への遷移を制限するため、詳細ボタンを非活性化しました。
- [X] Repository、DTO、Service の各層に `with_trashed` に関する単体テストを追加しました。

```
■ 修正前（検索結果のループ内）
<td>
    <a class="btn btn-primary btn-sm"
       href="{{ route('admin.user.show', ['user' => $user]) }}">詳細</a>
</td>

■ 修正後
<td>
    @if ($user->trashed())
        <span class="badge bg-danger">退会済</span>
    @endif
</td>
<td>
    <a class="btn btn-primary btn-sm {{ $user->trashed() ? 'disabled' : '' }}"
       href="{{ route('admin.user.show', ['user' => $user]) }}">詳細</a>
</td>
```

## やらないこと
<!-- このPRでやらないことは何か？ -->

- [X] 退会済みユーザーの詳細情報の閲覧（本PRでは一覧表示と検索までを対象としています）
- [X] 退会済みユーザーの復元機能の実装


## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->

- [X] 管理画面のユーザー一覧画面
- [X] ユーザー検索API（DTOおよびRepository層）


## テスト
<!-- テスト方法や結果 -->

- [X] 検索フォームの「退会済みを含む」にチェックを入れた際、論理削除されたユーザーが表示されることを確認しました。
- [X] チェックを外した際、通常のユーザーのみが表示されることを確認しました。
- [X] 退会済みユーザーの「詳細」ボタンがクリック不可（disabled）になっていることを確認しました。
- [X] 追加した単体テストがすべてパスすることを確認しました。

<!-- 画像を添付 -->
![画像](xxxx "画像")

<!-- 動画を添付 -->
<video controls playsinline width="100%" autoplay loop muted="true" src="xxxx" type="video/mp4" >
 Sorry, your browser doesn't support embedded videos.
</video>

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- [X] 特になし